### PR TITLE
Avoid adding space if whitespace exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,15 @@
 'use strict';
 
+var noWhitespace = /^\w+/;
+
 module.exports.tokenBefore = function(token) {
-	if (token.type === 'LineComment') {
-		token.raw = '// ' + token.value;
+	if(!token.value || token.type !== 'LineComment') {
+		return;
 	}
+
+	if (noWhitespace.test(token.value)) {
+		token.raw = '// ' + token.value;
+		return;
+	}
+
 };

--- a/test.js
+++ b/test.js
@@ -20,4 +20,51 @@ mocha.describe('spaced-lined-comment', function() {
 		// Then.
 		assert.equal(formattedCode, '// Comment string');
 	})
+
+	mocha.it('should not modify a comment if it has a leading space.', function() {
+		// Given.
+		var codeStr = '// Comment string';
+
+		// When.
+		var formattedCode = esformatter.format(codeStr);
+
+		// Then.
+		assert.equal(formattedCode, '// Comment string');
+	})
+
+	mocha.it('should not modify a comment if it has many leading spaces.', function() {
+		// Given.
+		var codeStr = '//  Comment string';
+
+		// When.
+		var formattedCode = esformatter.format(codeStr);
+
+		// Then.
+		assert.equal(formattedCode, '//  Comment string');
+	})
+
+	mocha.it('should not add a space if there is no text after slashes', function() {
+		// Given.
+		var codeStr = '//';
+
+		// When.
+		var formattedCode = esformatter.format(codeStr);
+
+		// Then.
+		assert.equal(formattedCode, '//');
+	})
+
+
+	mocha.it('should avoid adding more whitespace', function() {
+		// Given.
+		var codeStr = '//   ';
+
+		// When.
+		var formattedCode = esformatter.format(codeStr);
+
+		// Then.
+		assert.equal(formattedCode, '//   ');
+	})
+
+
 });


### PR DESCRIPTION
Add regex to ensure only comments without a leading space are modified.

Also added tests:
- should not modify a comment if it has a space
- should not modify a comment if it has many leading spaces
- should not add a space if there is no text after slashes
- should avoid adding more whitespace

Closes #1
